### PR TITLE
set SSL context to unverified

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -52,6 +52,9 @@ from requests.exceptions import HTTPError
 
 import mutagen
 
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context # quick fix for SSL issues
+
 from scdl import __version__
 from scdl import utils
 


### PR DESCRIPTION
scdl.py line 55-56. Add 'import SSL' and config context to 'unverified' to fix SSL not verifying

