### PR TITLE
setting user variable to pass downloading all of users favorites 

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -197,6 +197,7 @@ def parse_url(track_url):
         download_playlist(playlist)
     elif item.kind == 'user':
         logger.info('Found a user profile')
+        user = who_am_i()
         if arguments['-f']:
             download(user, 'favorites', 'likes')
         elif arguments['-t']:


### PR DESCRIPTION
running `scdl -l https://soundcloud.com/zfunk-2 -f -c ` causes this exception

```
Soundcloud Downloader

Found a user profile
Traceback (most recent call last):
  File "/spare/local/projects/soundcloud/venv/bin/scdl", line 9, in <module>
    load_entry_point('scdl==1.5.0.post2', 'console_scripts', 'scdl')()
  File "/spare/local/projects/soundcloud/venv/lib/python3.4/site-packages/scdl/scdl.py", line 128, in main
    parse_url(arguments['-l'])
  File "/spare/local/projects/soundcloud/venv/lib/python3.4/site-packages/scdl/scdl.py", line 201, in parse_url
    download(user, 'favorites', 'likes')
NameError: name 'user' is not defined
```

when setting `user = who_am_i()` it calls the function properly and downloads all the songs