### PR TITLE
adding six to required dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
         'soundcloud',
         'termcolor',
         'requests',
-        'clint'
+        'clint',
+        'six'
     ],
     url='https://github.com/flyingrub/scdl',
     classifiers=[


### PR DESCRIPTION
After installing scdl complained about not having `six` installed

```
Traceback (most recent call last):
  File "/spare/local/projects/scdl/venv/bin/scdl", line 9, in <module>
    load_entry_point('scdl==1.5.0.post3', 'console_scripts', 'scdl')()
  File "/spare/local/projects/scdl/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 519, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/spare/local/projects/scdl/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2630, in load_entry_point
    return ep.load()
  File "/spare/local/projects/scdl/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2310, in load
    return self.resolve()
  File "/spare/local/projects/scdl/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2316, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/spare/local/projects/scdl/venv/lib/python3.4/site-packages/scdl/scdl.py", line 56, in <module>
    from scdl import soundcloud, utils
  File "/spare/local/projects/scdl/venv/lib/python3.4/site-packages/scdl/soundcloud.py", line 4, in <module>
    import soundcloud
  File "/spare/local/projects/scdl/venv/lib/python3.4/site-packages/soundcloud/__init__.py", line 8, in <module>
    from soundcloud.client import Client
  File "/spare/local/projects/scdl/venv/lib/python3.4/site-packages/soundcloud/client.py", line 8, in <module>
    from soundcloud.request import make_request
  File "/spare/local/projects/scdl/venv/lib/python3.4/site-packages/soundcloud/request.py", line 7, in <module>
    import six
```