### PR TITLE
Fix downloading all track with '-a'

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -253,12 +253,12 @@ def download(user, dl_type, name):
                 name.capitalize(), counter + offset, total)
             )
             if name == 'tracks and reposts':
-                name = ''
+                item_name = ''
                 if item['type'] == 'track-repost':
-                    name = 'track'
+                    item_name = 'track'
                 else:
-                    name = item['type']
-                uri = item[name]['uri']
+                    item_name = item['type']
+                uri = item[item_name]['uri']
                 parse_url(uri)
             elif name == 'playlists':
                 download_playlist(item)


### PR DESCRIPTION
Variable 'name' is local to the function and it was overwritten
during the iteration which caused download of all repost tracks
after the first iteration to fail.

Fixes #130.