### PR TITLE
wav/flac to mp3, more ID3 tags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(
         'mutagen',
         'termcolor',
         'requests',
-        'clint'
+        'clint',
+        'wget'
     ],
     url='https://github.com/flyingrub/scdl',
     classifiers=[


### PR DESCRIPTION
- Add wav/flac to mp3 conversion via `lame`
- Add year and date to ID3 tags
- Add comment with URL to ID3 tags
- Add `--rewritefile` option - This rewrites the file name for "original file" downloads to the same format as normal downloads

Sorry there are multiple features in one PR - I've been maintaining this fork for quite a while and rebasing in upstream changes became too much effort!
