### PR TITLE
Use client_id better in URLs and download original properly

### DIFF
--- a/scdl/client.py
+++ b/scdl/client.py
@@ -9,9 +9,10 @@ class Client():
     def get_collection(self, url):
         resources = list()
         while url:
-            url = '{0}&client_id={1}&linked_partitioning=1'.format(
-                url, CLIENT_ID)
-            response = requests.get(url)
+            response = requests.get(url, params={
+                'client_id': CLIENT_ID,
+                'linked_partitioning': '1',
+            })
             json_data = response.json()
             if 'collection' in json_data:
                 resources.extend(json_data['collection'])


### PR DESCRIPTION
Before, the client_id was being added to the URL in an error-prone way.
This patch now uses requests to add it to the main request URL. Also,
the original download request is now being used properly where before it
was possible for the stream URL to be used.

This could be further improved by abstracting out the retrying of client
ids, but this is just to fix what's there at the moment.