### PR TITLE
Fixed issue with tagging files like MUSIC.MP3 (uppercase extension)

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -395,7 +395,8 @@ def download_track(track, playlist_name=None, playlist_file=None):
 
     invalid_chars = '\/:*?|<>"'
     filename = ''.join(c for c in filename if c not in invalid_chars)
-
+    base, ext = os.path.splitext(filename)
+    filename = base + ext.lower()
     logger.debug("filename : {0}".format(filename))
     # Add the track to the generated m3u playlist file
     if playlist_file:


### PR DESCRIPTION
For example: https://soundcloud.com/bakinbakes/turntville-usa downloads to `Summer Rage.MP3`, and since that filename doesn't end in `.mp3`, it doesn't get recognized later in the program as an mp3 file (see [this line](https://github.com/flyingrub/scdl/blob/master/scdl/scdl.py#L444) ). This PR normalizes file extensions to lowercase. 