### PR TITLE
[fix] --addtofile duplicate artists

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -390,8 +390,9 @@ def try_utime(path, filetime):
 def get_filename(track, title, is_original = False):
     invalid_chars = '\/:*?|<>"'
     username = track['user']['username']
-    if username not in title and arguments['--addtofile']:
-        title = '{0} - {1}'.format(username, title)
+    if arguments['--addtofile']:
+        if username not in title and '-' not in title
+            title = '{0} - {1}'.format(username, title)
 
     if arguments['--addtimestamp']:
         # created_at sample: 2017/03/03 09:29:33 +0000


### PR DESCRIPTION
checks for '-' in the title, to avoid adding the uploader before the pre-existing artist

eg. avoid this: "uploader - artist - song"