### PR TITLE
fixing connection closed prematurely error for missing playlist tracks

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -522,8 +522,10 @@ def download_track(track, playlist_name=None, playlist_file=None):
                 f.flush()
 
     if received != total_length:
-        logger.error('connection closed prematurely, download incomplete')
-        sys.exit()
+        logger.error('connection closed prematurely, download incomplete, Skipping...')
+        # sys.exit()
+        # handling missing playlist tracks
+        return
 
     shutil.move(temp.name, os.path.join(os.getcwd(), filename))
     if arguments['--flac'] and can_convert(filename):


### PR DESCRIPTION
Fixed the error that downloading process aborts due to missing records at playlists.