### PR TITLE
Add flag to save track cover art in separate file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ scdl me -f
     --onlymp3                   Download only the streamable mp3 file, even if track has a Downloadable file
     --path [path]               Use a custom path for downloaded files
     --remove                    Remove any files not downloaded from execution
+    --write-cover               Download track cover art of tracks as seperate image file
 ```
 
 

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -49,7 +49,7 @@ Options:
     --path [path]               Use a custom path for downloaded files
     --remove                    Remove any files not downloaded from execution
     --flac                      Convert original files to .flac
-    --write-cover               Download track cover of tracks as seperate image file
+    --write-cover               Download track cover art of tracks as seperate image file
 """
 
 import logging


### PR DESCRIPTION
**Addresses feature request:**
#279 

**New arg flag** `--write-cover`:
For each track downloaded, a separate .jpg file is created of the track cover.
Image file takes file name format of `<SONGNAME> TRACK ART.jpg`

**NOTE**
Does not check whether specific track cover has been downloaded before by other tracks of the same album.

New function `download_track_art(track)` 