### PR TITLE
Added --fullpermissions option to allow rwx for all users. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ scdl me -f
     --onlymp3                   Download only the streamable mp3 file, even if track has a Downloadable file
     --path [path]               Use a custom path for downloaded files
     --remove                    Remove any files not downloaded from execution
+    --fullpermissions           Updates *nix permissions for downloaded file to read/write/execute for everyone (equivalent to chmod 777).
 ```
 
 


### PR DESCRIPTION
This optional command line argument updates each downloaded file to have read/write/execute permissions for all users on Linux and Mac systems. Currently, downloaded files are only accessible by the user who created the files, which poses issues on multi-user systems. 
