### PR TITLE
Fix --addtimestamp and already downloaded fail

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -506,7 +506,7 @@ def download_hls_mp3(track, title):
 
     # Skip if file ID or filename already exists
     if already_downloaded(track, title, filename):
-        return
+        return filename
 
     # Get the requests stream
     url = get_track_m3u8(track)

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -416,9 +416,9 @@ def get_filename(track, original_filename=None):
             logger.debug('Adding "{0}" to filename'.format(username))
 
     if arguments['--addtimestamp']:
-        # created_at sample: 2017/03/03 09:29:33 +0000
+        # created_at sample: 2019-01-30T11:11:37Z
         ts = datetime\
-            .strptime(track['created_at'], "%Y/%m/%d %H:%M:%S %z")\
+            .strptime(track['created_at'], "%Y-%m-%dT%H:%M:%SZ")\
             .timestamp()
 
         title = str(int(ts)) + "_" + title


### PR DESCRIPTION
Fix two small bugs:
1. Make `--addtimestamp` working again by using the same strptime directives as in other functions.
2. Don't fail in case of already downloaded file by returning the filename in that case.

Maybe some useful links for tests:
https://soundcloud.com/falling-ethics/jk-flesh-static-demon-fexelvn004
https://soundcloud.com/byazade/sets/top-50-classical