### PR TITLE
respect XDG_CONFIG_HOME environment variable

### DIFF
--- a/scdl/__init__.py
+++ b/scdl/__init__.py
@@ -9,19 +9,21 @@ CLIENT_ID = 'a3e059563d7fd3372b49b37f00a00bcf'
 ALT_CLIENT_ID = '2t9loNQH90kzJcsFCODdigxfp325aq4z'
 ALT2_CLIENT_ID = 'NONE'
 
-dir_path_to_conf = os.path.join(os.path.expanduser('~'), '.config/scdl')
-if 'XDG_CONFIG_HOME' in os.environ:
-    dir_path_to_conf = os.environ['XDG_CONFIG_HOME']
-
-file_path_to_conf = os.path.join(dir_path_to_conf, 'scdl.cfg')
-text = """[scdl]
+default_config = """[scdl]
 auth_token =
 path = .
 """
 
-if not os.path.exists(dir_path_to_conf):
-    os.makedirs(dir_path_to_conf)
+if 'XDG_CONFIG_HOME' in os.environ:
+    config_dir = os.path.join(os.environ['XDG_CONFIG_HOME'], 'scdl')
+else:
+    config_dir = os.path.join(os.path.expanduser('~'), '.config', 'scdl')
 
-if not os.path.exists(file_path_to_conf):
-    with open(file_path_to_conf, 'w') as f:
-        f.write(text)
+config_file = os.path.join(config_dir, 'scdl.cfg')
+
+if not os.path.exists(config_file):
+    if not os.path.exists(config_dir):
+        os.makedirs(config_dir)
+
+    with open(config_file, 'w') as f:
+        f.write(default_config)

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -202,7 +202,16 @@ def get_config():
     """
     global token
     config = configparser.ConfigParser()
-    config.read(os.path.join(os.path.expanduser('~'), '.config/scdl/scdl.cfg'), "utf8")
+
+    if 'XDG_CONFIG_HOME' in os.environ:
+        config_file = os.path.join(
+            os.environ['XDG_CONFIG_HOME'], 'scdl', 'scdl.cfg',
+        )
+    else:
+        config_file = os.path.join(
+            os.path.expanduser('~'), '.config', 'scdl', 'scdl.cfg',
+        )
+    config.read(config_file, 'utf8')
     try:
         token = config['scdl']['auth_token']
         path = config['scdl']['path']
@@ -444,7 +453,7 @@ def download_original_file(track, title):
     if r.status_code == 401:
         logger.info('The original file has no download left.')
         return None
-    
+
     if r.status_code == 404:
         logger.info('Could not get name from stream - using basic name')
         return None
@@ -484,7 +493,7 @@ def download_original_file(track, title):
         newfilename = filename[:-4] + ".flac"
         new = shlex.quote(newfilename)
         old = shlex.quote(filename)
-        
+
         commands = ['ffmpeg', '-i', old, new, '-loglevel', 'fatal']
         logger.debug("Commands: {}".format(commands))
         subprocess.call(commands)


### PR DESCRIPTION
This fixes two bugs:

1. When XDG_CONFIG_HOME was set the scdl.cfg file was created at
   XDG_CONFIG_HOME/scdl.cfg not XDG_CONFIG_HOME/scdl/scdl.cfg
2. get_config() did not check for the XDG_CONFIG_HOME environment
   variable and read from ~/.config/scdl/scdl.cfg instead