### PR TITLE
Skipping download attempt if a file is no longer available in Soundcloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.egg-info/
 __pycache__/
 *.mp3
+.python-version

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,11 @@ from setuptools import setup, find_packages
 
 import scdl
 
+from os import path
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
 setup(
     name='scdl',
     version=scdl.__version__,
@@ -12,7 +17,8 @@ setup(
     author='FlyinGrub',
     author_email='flyinggrub@gmail.com',
     description='Download Music from Souncloud',
-    long_description="README on github : https://github.com/flyingrub/scdl",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     install_requires=[
         'docopt',
         'mutagen',


### PR DESCRIPTION
As noted in #314, if a file no longer exists in the soundcloud UI, it can still be returned from the API. This results in a failure to download, and the remaining entries are not processed. This fix will address that problem.

I also took the opportunity to convert some of the log statements to f-strings where ableto do so.

fixes #314 