### PR TITLE
Implement version 2 of soundcloud API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,129 @@
-build/
-dist/
-*.pyc
-*.egg-info/
+# Byte-compiled / optimized / DLL files
 __pycache__/
-*.mp3
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -91,19 +91,19 @@ offset = 1
 url = {
     'playlists-liked': ('https://api-v2.soundcloud.com/users/{0}/playlists'
                         '/liked_and_owned?limit=200'),
-    'favorites': ('https://api.soundcloud.com/users/{0}/favorites?'
+    'favorites': ('https://api-v2.soundcloud.com/users/{0}/favorites?'
                   'limit=200'),
-    'commented': ('https://api.soundcloud.com/users/{0}/comments'),
-    'tracks': ('https://api.soundcloud.com/users/{0}/tracks?'
+    'commented': ('https://api-v2.soundcloud.com/users/{0}/comments'),
+    'tracks': ('https://api-v2.soundcloud.com/users/{0}/tracks?'
                'limit=200'),
     'all': ('https://api-v2.soundcloud.com/profile/soundcloud:users:{0}?'
             'limit=200'),
-    'playlists': ('https://api.soundcloud.com/users/{0}/playlists?'
+    'playlists': ('https://api-v2.soundcloud.com/users/{0}/playlists?'
                   'limit=5'),
-    'resolve': ('https://api.soundcloud.com/resolve?url={0}'),
+    'resolve': ('https://api-v2.soundcloud.com/resolve?url={0}'),
     'trackinfo': ('https://api-v2.soundcloud.com/tracks/{0}'),
-    'user': ('https://api.soundcloud.com/users/{0}'),
-    'me': ('https://api.soundcloud.com/me?oauth_token={0}')
+    'user': ('https://api-v2.soundcloud.com/users/{0}'),
+    'me': ('https://api-v2.soundcloud.com/me?oauth_token={0}')
 }
 client = client.Client()
 
@@ -449,7 +449,7 @@ def download_original_file(track, title):
     if r.status_code == 401:
         logger.info('The original file has no download left.')
         return None
-    
+
     if r.status_code == 404:
         logger.info('Could not get name from stream - using basic name')
         return None
@@ -489,7 +489,7 @@ def download_original_file(track, title):
         newfilename = filename[:-4] + ".flac"
         new = shlex.quote(newfilename)
         old = shlex.quote(filename)
-        
+
         commands = ['ffmpeg', '-i', old, new, '-loglevel', 'fatal']
         logger.debug("Commands: {}".format(commands))
         subprocess.call(commands)

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -25,7 +25,7 @@ Options:
     -s                          Download the stream of a user (token needed)
     -a                          Download all tracks of user (including reposts)
     -t                          Download all uploads of a user (no reposts)
-    -f                          Download all favorites of a user
+    -f                          Download all track_likes of a user
     -C                          Download all commented by a user
     -p                          Download all playlists of a user
     -m                          Download all liked and owned playlists of user
@@ -91,7 +91,7 @@ offset = 1
 url = {
     'playlists-liked': ('https://api-v2.soundcloud.com/users/{0}/playlists'
                         '/liked_and_owned?limit=200'),
-    'favorites': ('https://api-v2.soundcloud.com/users/{0}/favorites?'
+    'track_likes': ('https://api-v2.soundcloud.com/users/{0}/track_likes?'
                   'limit=200'),
     'commented': ('https://api-v2.soundcloud.com/users/{0}/comments'),
     'tracks': ('https://api-v2.soundcloud.com/users/{0}/tracks?'
@@ -181,7 +181,7 @@ def main():
         parse_url(arguments['-l'])
     elif arguments['me']:
         if arguments['-f']:
-            download(who_am_i(), 'favorites', 'likes')
+            download(who_am_i(), 'track_likes', 'likes')
         if arguments['-C']:
             download(who_am_i(), 'commented', 'commented tracks')
         elif arguments['-t']:
@@ -268,7 +268,7 @@ def parse_url(track_url):
     elif item['kind'] == 'user':
         logger.info('Found a user profile')
         if arguments['-f']:
-            download(item, 'favorites', 'likes')
+            download(item, 'track_likes', 'likes')
         elif arguments['-C']:
             download(item, 'commented', 'commented tracks')
         elif arguments['-t']:


### PR DESCRIPTION
It looks like Soundcloud wants to use `api-v2` #318 
- [x] Updated API endpoints `https://api.soundcloud.com...` to `https://api-v2.soundcloud.com...`
- [x] Updated the old API endpoint `/favorites` to `/track-likes` (https://github.com/flyingrub/scdl/issues/318#issuecomment-602141393)
- [ ] Patch api urls returned from Soundcloud (for example, the `download-url` returned is an `api` v1 link)