### PR TITLE
Add support for downloading and tagging 256 kbps AAC files

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -71,6 +71,7 @@ import shutil
 
 import configparser
 import mutagen
+from mutagen.easymp4 import EasyMP4
 from docopt import docopt
 from clint.textui import progress
 
@@ -238,7 +239,8 @@ def get_item(track_url, client_id=CLIENT_ID):
     try:
         item_url = url['resolve'].format(track_url)
 
-        r = requests.get(item_url, params={'client_id': client_id})
+        headers = {'Authorization': 'OAuth {0}'.format(token)} if token else {}
+        r = requests.get(item_url, params={'client_id': client_id}, headers=headers)
         logger.debug(r.url)
         if r.status_code == 403:
             return get_item(track_url, ALT_CLIENT_ID)
@@ -432,7 +434,7 @@ def try_utime(path, filetime):
         logger.error("Cannot update utime of file")
 
 
-def get_filename(track, original_filename=None):
+def get_filename(track, original_filename=None, aac=False):
     invalid_chars = '\/:*?|<>"'
     username = track['user']['username']
     title = track['title'].encode('utf-8', 'ignore').decode('utf8')
@@ -450,7 +452,7 @@ def get_filename(track, original_filename=None):
 
         title = str(int(ts)) + "_" + title
 
-    ext = ".mp3"
+    ext = ".m4a" if aac else ".mp3" # contain aac in m4a to write metadata
     if original_filename is not None:
         original_filename.encode('utf-8', 'ignore').decode('utf8')
         ext = os.path.splitext(original_filename)[1]
@@ -521,28 +523,33 @@ def download_original_file(track, title):
     return (filename, False)
 
 
-def get_track_m3u8(track):
+def get_track_m3u8(track, aac=False):
     url = None
     for transcoding in track['media']['transcodings']:
-        if transcoding['format']['protocol'] == 'hls' \
-                and transcoding['format']['mime_type'] == 'audio/mpeg':
-            url = transcoding['url']
+        if transcoding['format']['protocol'] == 'hls':
+            if (not aac and transcoding['format']['mime_type'] == 'audio/mpeg') \
+                    or (aac and transcoding['format']['mime_type'].startswith('audio/mp4')):
+                url = transcoding['url']
 
     if url is not None:
-        r = requests.get(url, params={'client_id': CLIENT_ID})
+        headers = {'Authorization': 'OAuth {0}'.format(token)} if aac else {}
+        r = requests.get(url, params={'client_id': CLIENT_ID}, headers=headers)
         logger.debug(r.url)
         return r.json()['url']
 
 
-def download_hls_mp3(track, title):
-    filename = get_filename(track)
+def download_hls(track, title):
+
+    aac = any(t['format']['mime_type'].startswith('audio/mp4') for t in track['media']['transcodings'])
+
+    filename = get_filename(track, None, aac)
     logger.debug("filename : {0}".format(filename))
     # Skip if file ID or filename already exists
     if already_downloaded(track, title, filename):
         return (filename, True)
 
     # Get the requests stream
-    url = get_track_m3u8(track)
+    url = get_track_m3u8(track, aac)
     filename_path = os.path.abspath(filename)
 
     subprocess.call(['ffmpeg', '-i', url, '-c', 'copy', filename_path, '-loglevel', 'fatal'])
@@ -576,7 +583,7 @@ def download_track(track, playlist_info=None):
         filename, is_already_downloaded = download_original_file(track, title)
 
     if filename is None:
-        filename, is_already_downloaded = download_hls_mp3(track, title)
+        filename, is_already_downloaded = download_hls(track, title)
 
     # Add the track to the generated m3u playlist file
     if playlist_info:
@@ -604,7 +611,7 @@ def download_track(track, playlist_info=None):
         sys.exit(-1)
 
     # Try to set the metadata
-    if filename.endswith('.mp3') or filename.endswith('.flac'):
+    if filename.endswith('.mp3') or filename.endswith('.flac') or filename.endswith('.m4a'):
         try:
             set_metadata(track, filename, playlist_info)
         except Exception as e:
@@ -726,6 +733,8 @@ def set_metadata(track, filename, playlist_info=None):
                     track['title'] = artist_title[1].strip()
                     break
 
+        EasyMP4.RegisterTextKey('website', 'purl')
+
         audio = mutagen.File(filename, easy=True)
         audio['title'] = track['title']
         audio['artist'] = track['artist']
@@ -747,6 +756,8 @@ def set_metadata(track, filename, playlist_info=None):
                 a['COMM'] = mutagen.id3.COMM(
                     encoding=3, lang=u'ENG', text=track['description']
                 )
+            elif a.__class__ == mutagen.mp4.MP4:
+                a['\xa9cmt'] = track['description']
         if artwork_url:
             if a.__class__ == mutagen.flac.FLAC:
                 p = mutagen.flac.Picture()
@@ -760,6 +771,8 @@ def set_metadata(track, filename, playlist_info=None):
                     encoding=3, mime='image/jpeg', type=3,
                     desc='Cover', data=out_file.read()
                 )
+            elif a.__class__ == mutagen.mp4.MP4:
+                a['covr'] = [mutagen.mp4.MP4Cover(out_file.read())]
         a.save()
 
 

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -543,7 +543,10 @@ def get_track_m3u8(track, aac=False):
 
 def download_hls(track, title):
 
-    aac = any(t['format']['mime_type'].startswith('audio/mp4') for t in track['media']['transcodings'])
+    if arguments['--onlymp3']:
+        aac = False
+    else:
+        aac = any(t['format']['mime_type'].startswith('audio/mp4') for t in track['media']['transcodings'])
 
     filename = get_filename(track, None, aac)
     logger.debug("filename : {0}".format(filename))

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -71,7 +71,10 @@ import shutil
 
 import configparser
 import mutagen
+
 from mutagen.easymp4 import EasyMP4
+EasyMP4.RegisterTextKey('website', '\xa9cmt')
+
 from docopt import docopt
 from clint.textui import progress
 
@@ -733,8 +736,6 @@ def set_metadata(track, filename, playlist_info=None):
                     track['title'] = artist_title[1].strip()
                     break
 
-        EasyMP4.RegisterTextKey('website', 'purl')
-
         audio = mutagen.File(filename, easy=True)
         audio['title'] = track['title']
         audio['artist'] = track['artist']
@@ -757,7 +758,7 @@ def set_metadata(track, filename, playlist_info=None):
                     encoding=3, lang=u'ENG', text=track['description']
                 )
             elif a.__class__ == mutagen.mp4.MP4:
-                a['\xa9cmt'] = track['description']
+                a['desc'] = track['description']
         if artwork_url:
             if a.__class__ == mutagen.flac.FLAC:
                 p = mutagen.flac.Picture()

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -535,7 +535,7 @@ def get_track_m3u8(track, aac=False):
                 url = transcoding['url']
 
     if url is not None:
-        headers = {'Authorization': 'OAuth {0}'.format(token)} if aac else {}
+        headers = {'Authorization': 'OAuth {0}'.format(token)} if token else {}
         r = requests.get(url, params={'client_id': CLIENT_ID}, headers=headers)
         logger.debug(r.url)
         return r.json()['url']


### PR DESCRIPTION
If auth token is specified in scdl.cfg and the user has a GO+ account, download songs as 256 kbps AAC if available, put them in an m4a container and add metadata.

#353 #169 #361