### PR TITLE
Fix issue for limitting number of playlist entry downloads

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -395,7 +395,7 @@ def download_playlist(client: SoundCloud, playlist: BasicAlbumPlaylist, **kwargs
     try:
         if kwargs.get("n"):  # Order by creation date and get the n lasts tracks
             playlist.tracks.sort(
-                key=lambda track: track.created_at, reverse=True
+                key=lambda track: track.id, reverse=True
             )
             playlist.tracks = playlist.tracks[: int(kwargs.get("n"))]
         else:


### PR DESCRIPTION
created_at doesn't seem to be present in the MiniTrack class, but id will always
be present and works equally well.