### PR TITLE
Prefer filename* header

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -550,7 +550,10 @@ def download_original_file(client: SoundCloud, track: BasicTrack, title: str, pl
     # Find filename
     header = r.headers.get("content-disposition")
     _, params = cgi.parse_header(header)
-    if "filename" in params:
+    if "filename*" in params:
+        encoding, filename = params["filename*"].split("''")
+        filename = urllib.parse.unquote(filename, encoding=encoding)
+    else if "filename" in params:
         filename = urllib.parse.unquote(params["filename"], encoding="utf-8")
     else:
         raise SoundCloudException(f"Could not get filename from content-disposition header: {header}")

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -553,7 +553,7 @@ def download_original_file(client: SoundCloud, track: BasicTrack, title: str, pl
     if "filename*" in params:
         encoding, filename = params["filename*"].split("''")
         filename = urllib.parse.unquote(filename, encoding=encoding)
-    else if "filename" in params:
+    elif "filename" in params:
         filename = urllib.parse.unquote(params["filename"], encoding="utf-8")
     else:
         raise SoundCloudException(f"Could not get filename from content-disposition header: {header}")


### PR DESCRIPTION
Addresses #414 
The `filename*` parameter is preferred over the `filename` parameter in the content-disposition header in browsers, so this PR reflects that in the scdl code to get the desired filename.