### PR TITLE
Removed download count check

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -706,7 +706,6 @@ def download_track(client: SoundCloud, track: BasicTrack, playlist_info=None, ex
         is_already_downloaded = False
         if (
             track.downloadable
-            and track.has_downloads_left
             and not kwargs["onlymp3"]
             and not kwargs.get("no_original")
         ):


### PR DESCRIPTION
Resolves #431. When downloading from likes, scdl didn't recognize there was an original file due to the download count check returning the wrong value.