### PR TITLE
Playlist files, failsafe cleanup, multiple user actions, fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ scdl -l https://soundcloud.com/pandadub/sets/the-lost-ship --sync archive.txt
 
 # Download your likes (with authentification token)
 scdl me -f
+
+# Download your likes and tracks, generate playlist files
+scdl me -f -t --playlist-file
 ```
 
 ## Options:
@@ -87,6 +90,10 @@ scdl me -f
 --auth-token [token]            Specify the auth token to use
 --overwrite                     Overwrite file if it already exists
 --strict-playlist               Abort playlist downloading if one track fails to download
+--playlist-file                 Generate m3u playlist files (and additionally check them when used with --remove)
+--playlist-file-retain          Retain corrupted items
+--playlist-file-name            Specify playlist file name without extension
+--playlist-file-extension       Specify extension to playlist file
 ```
 
 

--- a/scdl/scdl.cfg
+++ b/scdl/scdl.cfg
@@ -3,7 +3,7 @@ client_id = a3e059563d7fd3372b49b37f00a00bcf
 auth_token =
 path = .
 name_format = {title}
-playlist_name_format = {playlist[title]}_{title}
+playlist_name_format = {title}
 
 # example name_format values:
 # {timestamp}_{user[username]}_{title}

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -820,6 +820,10 @@ def download_track(client: SoundCloud, track: BasicTrack, playlist_info=None, ex
         logger.error(err)
         return False
 
+    except BaseException as err:
+        logger.error(err)
+        return False
+
 def can_convert(filename):
     ext = os.path.splitext(filename)[1]
     return "wav" in ext or "aif" in ext

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -397,17 +397,22 @@ def download_url(client: SoundCloud, **kwargs):
             logger.info(f"Downloaded all playlists of user {user.username}!")
         if kwargs.get("r"):
             logger.info(f"Retrieving all reposts of user {user.username}...")
+            playlistbuffer=None if not kwargs.get("playlist_file") else []
+            subplaylistbuffer=None if not kwargs.get("playlist_file") else []
             resources = client.get_user_reposts(user.id, limit=1000)
             for i, item in itertools.islice(enumerate(resources, 1), offset, None):
                 logger.info(f"item n°{i} of {user.reposts_count or '?'}")
                 if item.type == "track-repost":
-                    download_track(client, item.track, exit_on_fail=kwargs.get("strict_playlist"), **kwargs)
+                    download_track(client, item.track, exit_on_fail=kwargs.get("strict_playlist"), playlist_buffer=playlistbuffer, **kwargs)
                 elif item.type == "playlist-repost":
-                    download_playlist(client, item.playlist, **kwargs)
+                    download_playlist(client, item.playlist, kwdefget("playlist_file_name", "Reposts", **kwargs) + " - ", subplaylist_buffer=subplaylistbuffer, **kwargs)
                 else:
                     logger.error(f"Unknown item type {item.type}")
                     if kwargs.get("strict_playlist"):
                         sys.exit(1)
+            if kwargs.get("playlist_file"):
+                playlist_process(client, playlistbuffer, kwdefget("playlist_file_name", "Reposts", **kwargs) + "." + kwdefget("playlist_file_extension", "m3u8", **kwargs), **kwargs)
+                playlist_process(client, subplaylistbuffer, kwdefget("playlist_file_name", "Reposts Playlists", **kwargs) + "." + kwdefget("playlist_file_extension", "m3u8", **kwargs), no_export=True, **kwargs)
             logger.info(f"Downloaded all reposts of user {user.username}!")
 
     else:

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -713,16 +713,18 @@ def download_hls(client: SoundCloud, track: BasicTrack, title: str, playlist_inf
 
     # Get the requests stream
     url = get_transcoding_m3u8(client, transcoding, **kwargs)
-    filename_path = os.path.abspath(filename)
+    temp = tempfile.NamedTemporaryFile(delete=False)
+    temp_filename = temp.name + os.path.splitext(filename)[1]
 
     p = subprocess.Popen(
-        ["ffmpeg", "-i", url, "-c", "copy", filename_path, "-loglevel", "error"],
+        ["ffmpeg", "-i", url, "-c", "copy", temp_filename, "-loglevel", "error"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE
     )
     stdout, stderr = p.communicate()
     if stderr:
         logger.error(stderr.decode("utf-8"))
+    shutil.move(temp_filename, os.path.join(os.getcwd(), filename))
     return (filename, False)
 
 

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -301,6 +301,9 @@ def get_config(config_file: pathlib.Path) -> configparser.ConfigParser:
         
     return config
 
+def kwdefget(findkey, defaultvalue, **kwargs):
+    if not kwargs.get(findkey): return defaultvalue
+    return kwargs.get(findkey)
 
 def download_url(client: SoundCloud, **kwargs):
     """

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -247,7 +247,7 @@ def main():
     download_url(client, **python_args)
 
     if arguments["--remove"]:
-        remove_files()
+        remove_files(arguments["--playlist-file"] is not None, kwdefget("playlist_file_extension", "m3u8", **python_args))
 
 
 def validate_url(client: SoundCloud, url: str):

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -1058,7 +1058,11 @@ def playlist_process(client: SoundCloud, playlist_buffer, playlist_filename, no_
     if no_export == False:
         playlist_export(playlist_buffer, playlist_filename)
 
-
+def playlist_map_write(playlist_buffer, playlist_filename):
+    if playlist_buffer is None or len(playlist_buffer) == 0: return
+    with open(playlist_filename + ".map", "w") as fout:
+        for playlist_item in playlist_buffer:
+            fout.write(str(playlist_item["id"]) + ":" + playlist_item["path"] + ":" + playlist_item["uri"] + "\n")
 
 def playlist_import(playlist_filename):
     try:

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -387,10 +387,13 @@ def download_url(client: SoundCloud, **kwargs):
             logger.info(f"Downloaded all tracks & reposts of user {user.username}!")
         if kwargs.get("p"):
             logger.info(f"Retrieving all playlists of user {user.username}...")
+            #subplaylistbuffer=None if not kwargs.get("playlist_file") else []
             resources = client.get_user_playlists(user.id, limit=1000)
             for i, playlist in itertools.islice(enumerate(resources, 1), offset, None):
                 logger.info(f"playlist n°{i} of {user.playlist_count}")
-                download_playlist(client, playlist, **kwargs)
+                download_playlist(client, playlist, **kwargs) # subplaylist_buffer=subplaylistbuffer, 
+            #if kwargs.get("playlist_file"):
+            #    playlist_process(client, subplaylistbuffer, kwdefget("playlist_file_name", "Playlists", **kwargs) + "." + kwdefget("playlist_file_extension", "m3u8", **kwargs), no_export=True, **kwargs)
             logger.info(f"Downloaded all playlists of user {user.username}!")
         if kwargs.get("r"):
             logger.info(f"Retrieving all reposts of user {user.username}...")

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -726,7 +726,7 @@ def download_track(client: SoundCloud, track: BasicTrack, playlist_info=None, ex
 
         # Skip if file ID or filename already exists
         if is_already_downloaded and not kwargs.get("force_metadata"):
-            raise SoundCloudException(f"{filename} already downloaded.")
+            raise SoundCloudSoftException(f"{filename} already downloaded.")
 
         # If file does not exist an error occurred
         if not os.path.isfile(filename):
@@ -753,11 +753,17 @@ def download_track(client: SoundCloud, track: BasicTrack, playlist_info=None, ex
         try_utime(filename, filetime)
 
         logger.info(f"{filename} Downloaded.\n")
+        return True
+        
     except SoundCloudException as err:
         logger.error(err)
         if exit_on_fail:
             sys.exit(1)
+        return False
 
+    except SoundCloudSoftException as err:
+        logger.error(err)
+        return False
 
 def can_convert(filename):
     ext = os.path.splitext(filename)[1]

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -696,7 +696,7 @@ def download_hls(client: SoundCloud, track: BasicTrack, title: str, playlist_inf
     return (filename, False)
 
 
-def download_track(client: SoundCloud, track: BasicTrack, playlist_info=None, exit_on_fail=True, **kwargs):
+def download_track(client: SoundCloud, track: BasicTrack, playlist_info=None, exit_on_fail=True, playlist_buffer=None, **kwargs):
     """
     Downloads a track
     """
@@ -735,6 +735,7 @@ def download_track(client: SoundCloud, track: BasicTrack, playlist_info=None, ex
 
         # Skip if file ID or filename already exists
         if is_already_downloaded and not kwargs.get("force_metadata"):
+            if playlist_buffer is not None: playlist_buffer.append({ "id": track.id, "path": filename, "uri": track.uri })
             raise SoundCloudSoftException(f"{filename} already downloaded.")
 
         # If file does not exist an error occurred
@@ -761,6 +762,7 @@ def download_track(client: SoundCloud, track: BasicTrack, playlist_info=None, ex
         filetime = int(time.mktime(track.created_at.timetuple()))
         try_utime(filename, filetime)
 
+        if playlist_buffer is not None: playlist_buffer.append({ "id": track.id, "path": filename, "uri": track.uri })
         logger.info(f"{filename} Downloaded.\n")
         return True
         

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -331,17 +331,22 @@ def download_url(client: SoundCloud, **kwargs):
             sys.exit(1)
         if kwargs.get("f"):
             logger.info(f"Retrieving all likes of user {user.username}...")
+            playlistbuffer=None if not kwargs.get("playlist_file") else []
+            subplaylistbuffer=None if not kwargs.get("playlist_file") else []
             resources = client.get_user_likes(user.id, limit=1000)
             for i, like in itertools.islice(enumerate(resources, 1), offset, None):
                 logger.info(f"like n°{i} of {user.likes_count}")
                 if hasattr(like, "track"):
-                    download_track(client, like.track, exit_on_fail=kwargs.get("strict_playlist"), **kwargs)
+                    download_track(client, like.track, exit_on_fail=kwargs.get("strict_playlist"), playlist_buffer=playlistbuffer, **kwargs)
                 elif hasattr(like, "playlist"):
-                    download_playlist(client, client.get_playlist(like.playlist.id), **kwargs)
+                    download_playlist(client, client.get_playlist(like.playlist.id), playlist_filename_prefix=kwdefget("playlist_file_name", "Likes", **kwargs) + " - ", subplaylist_buffer=subplaylistbuffer, **kwargs)
                 else:
                     logger.error(f"Unknown like type {like}")
                     if kwargs.get("strict_playlist"):
                         sys.exit(1)
+            if kwargs.get("playlist_file"):
+                playlist_process(client, playlistbuffer, kwdefget("playlist_file_name", "Likes", **kwargs) + "." + kwdefget("playlist_file_extension", "m3u8", **kwargs), **kwargs)
+                playlist_process(client, subplaylistbuffer, kwdefget("playlist_file_name", "Likes Playlists", **kwargs) + "." + kwdefget("playlist_file_extension", "m3u8", **kwargs), no_export=True, **kwargs)
             logger.info(f"Downloaded all likes of user {user.username}!")
         if kwargs.get("C"):
             logger.info(f"Retrieving all commented tracks of user {user.username}...")

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -350,10 +350,12 @@ def download_url(client: SoundCloud, **kwargs):
             logger.info(f"Downloaded all likes of user {user.username}!")
         if kwargs.get("C"):
             logger.info(f"Retrieving all commented tracks of user {user.username}...")
+            playlistbuffer=None if not kwargs.get("playlist_file") else []
             resources = client.get_user_comments(user.id, limit=1000)
             for i, comment in itertools.islice(enumerate(resources, 1), offset, None):
                 logger.info(f"comment n°{i} of {user.comments_count}")
-                download_track(client, client.get_track(comment.track.id), exit_on_fail=kwargs.get("strict_playlist"), **kwargs)
+                download_track(client, client.get_track(comment.track.id), exit_on_fail=kwargs.get("strict_playlist"), playlist_buffer=playlistbuffer, **kwargs)
+            if kwargs.get("playlist_file"): playlist_process(client, playlistbuffer, kwdefget("playlist_file_name", "Commented", **kwargs) + "." + kwdefget("playlist_file_extension", "m3u8", **kwargs), **kwargs)
             logger.info(f"Downloaded all commented tracks of user {user.username}!")
         if kwargs.get("t"):
             logger.info(f"Retrieving all tracks of user {user.username}...")

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -4,7 +4,7 @@
 """scdl allows you to download music from Soundcloud
 
 Usage:
-    scdl (-l <track_url> | me) [-a | -f | -C | -t | -p | -r][-c | --force-metadata]
+    scdl (-l <track_url> | me) [-a][-r][-t][-f][-C][-p][-c][--force-metadata]
     [-n <maxtracks>][-o <offset>][--hidewarnings][--debug | --error][--path <path>]
     [--addtofile][--addtimestamp][--onlymp3][--hide-progress][--min-size <size>]
     [--max-size <size>][--remove][--no-album-tag][--no-playlist-folder]

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -318,6 +318,9 @@ def download_url(client: SoundCloud, **kwargs):
     elif item.kind == "user":
         user = item
         logger.info("Found a user profile")
+        if not kwargs.get("f") and not kwargs.get("C") and not kwargs.get("t") and not kwargs.get("a") and not kwargs.get("p") and not kwargs.get("r"):
+            logger.error("Please provide a download type...")
+            sys.exit(1)
         if kwargs.get("f"):
             logger.info(f"Retrieving all likes of user {user.username}...")
             resources = client.get_user_likes(user.id, limit=1000)
@@ -332,21 +335,21 @@ def download_url(client: SoundCloud, **kwargs):
                     if kwargs.get("strict_playlist"):
                         sys.exit(1)
             logger.info(f"Downloaded all likes of user {user.username}!")
-        elif kwargs.get("C"):
+        if kwargs.get("C"):
             logger.info(f"Retrieving all commented tracks of user {user.username}...")
             resources = client.get_user_comments(user.id, limit=1000)
             for i, comment in itertools.islice(enumerate(resources, 1), offset, None):
                 logger.info(f"comment n°{i} of {user.comments_count}")
                 download_track(client, client.get_track(comment.track.id), exit_on_fail=kwargs.get("strict_playlist"), **kwargs)
             logger.info(f"Downloaded all commented tracks of user {user.username}!")
-        elif kwargs.get("t"):
+        if kwargs.get("t"):
             logger.info(f"Retrieving all tracks of user {user.username}...")
             resources = client.get_user_tracks(user.id, limit=1000)
             for i, track in itertools.islice(enumerate(resources, 1), offset, None):
                 logger.info(f"track n°{i} of {user.track_count}")
                 download_track(client, track, exit_on_fail=kwargs.get("strict_playlist"), **kwargs)
             logger.info(f"Downloaded all tracks of user {user.username}!")
-        elif kwargs.get("a"):
+        if kwargs.get("a"):
             logger.info(f"Retrieving all tracks & reposts of user {user.username}...")
             resources = client.get_user_stream(user.id, limit=1000)
             for i, item in itertools.islice(enumerate(resources, 1), offset, None):
@@ -360,14 +363,14 @@ def download_url(client: SoundCloud, **kwargs):
                     if kwargs.get("strict_playlist"):
                         sys.exit(1)
             logger.info(f"Downloaded all tracks & reposts of user {user.username}!")
-        elif kwargs.get("p"):
+        if kwargs.get("p"):
             logger.info(f"Retrieving all playlists of user {user.username}...")
             resources = client.get_user_playlists(user.id, limit=1000)
             for i, playlist in itertools.islice(enumerate(resources, 1), offset, None):
                 logger.info(f"playlist n°{i} of {user.playlist_count}")
                 download_playlist(client, playlist, **kwargs)
             logger.info(f"Downloaded all playlists of user {user.username}!")
-        elif kwargs.get("r"):
+        if kwargs.get("r"):
             logger.info(f"Retrieving all reposts of user {user.username}...")
             resources = client.get_user_reposts(user.id, limit=1000)
             for i, item in itertools.islice(enumerate(resources, 1), offset, None):
@@ -381,9 +384,7 @@ def download_url(client: SoundCloud, **kwargs):
                     if kwargs.get("strict_playlist"):
                         sys.exit(1)
             logger.info(f"Downloaded all reposts of user {user.username}!")
-        else:
-            logger.error("Please provide a download type...")
-            sys.exit(1)
+
     else:
         logger.error(f"Unknown item type {item.kind}")
         sys.exit(1)

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -359,10 +359,12 @@ def download_url(client: SoundCloud, **kwargs):
             logger.info(f"Downloaded all commented tracks of user {user.username}!")
         if kwargs.get("t"):
             logger.info(f"Retrieving all tracks of user {user.username}...")
+            playlistbuffer=None if not kwargs.get("playlist_file") else []
             resources = client.get_user_tracks(user.id, limit=1000)
             for i, track in itertools.islice(enumerate(resources, 1), offset, None):
                 logger.info(f"track n°{i} of {user.track_count}")
-                download_track(client, track, exit_on_fail=kwargs.get("strict_playlist"), **kwargs)
+                download_track(client, track, exit_on_fail=kwargs.get("strict_playlist"), playlist_buffer=playlistbuffer, **kwargs)
+            if kwargs.get("playlist_file"): playlist_process(client, playlistbuffer, kwdefget("playlist_file_name", "Tracks", **kwargs) + "." + kwdefget("playlist_file_extension", "m3u8", **kwargs), **kwargs)
             logger.info(f"Downloaded all tracks of user {user.username}!")
         if kwargs.get("a"):
             logger.info(f"Retrieving all tracks & reposts of user {user.username}...")

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -1058,6 +1058,18 @@ def playlist_process(client: SoundCloud, playlist_buffer, playlist_filename, no_
     if no_export == False:
         playlist_export(playlist_buffer, playlist_filename)
 
+def playlist_map_read(playlist_filename):
+    try:
+        res = []
+        if not os.path.isfile(playlist_filename + ".map"): return res
+        with open(playlist_filename + ".map", "r") as fin:
+            for fline in fin.read().splitlines():
+                ffields = fline.split(":", 2)
+                if len(ffields) == 3: res.append({ "id": ffields[0], "path": ffields[1], "uri": ffields[2] })
+        return res
+    except Exception:
+        return []
+
 def playlist_map_write(playlist_buffer, playlist_filename):
     if playlist_buffer is None or len(playlist_buffer) == 0: return
     with open(playlist_filename + ".map", "w") as fout:

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -543,6 +543,9 @@ def download_playlist(client: SoundCloud, playlist: BasicAlbumPlaylist, playlist
                 playlist_filename=playlist_filename_prefix + playlist_name + ".m3u8"
                 playlist_process(client, playlistbuffer, playlist_filename, **kwargs)
                 if subplaylist_buffer: subplaylist_buffer.append({ "id": playlist.id, "path": playlist_filename, "uri": playlist.uri })
+    except BaseException as err:
+        logger.error(err)
+        return False
     finally:
         if not kwargs.get("no_playlist_folder"):
             os.chdir("..")

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -482,6 +482,9 @@ def download_playlist(client: SoundCloud, playlist: BasicAlbumPlaylist, **kwargs
             )
             playlist.tracks = playlist.tracks[: int(kwargs.get("n"))]
             kwargs["playlist_offset"] = 0
+
+        if not playlist.tracks or len(playlist.tracks) == 0: return
+            
         if kwargs.get("sync"):
                   if os.path.isfile(kwargs.get("sync")):
                         playlist.tracks = sync(client, playlist, playlist_info, **kwargs)

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -1058,5 +1058,13 @@ def playlist_process(client: SoundCloud, playlist_buffer, playlist_filename, no_
     if no_export == False:
         playlist_export(playlist_buffer, playlist_filename)
 
+
+
+def playlist_export(playlist_buffer, playlist_filename):
+    with open(playlist_filename, "w") as fout:
+        for playlist_item in playlist_buffer:
+            fout.write(playlist_item["path"] + "\n")
+
+
 if __name__ == "__main__":
     main()

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -920,16 +920,19 @@ def set_metadata(track: BasicTrack, filename: str, playlist_info=None, **kwargs)
             ):
                 response = None
         except Exception:
-            pass
-    if response is None:
-        new_artwork_url = artwork_url.replace("large", "t500x500")
-        response = requests.get(new_artwork_url, stream=True)
-        if response.headers["Content-Type"] not in (
-            "image/png",
-            "image/jpeg",
-            "image/jpg",
-        ):
             response = None
+    try:
+        if response is None:
+            new_artwork_url = artwork_url.replace("large", "t500x500")
+            response = requests.get(new_artwork_url, stream=True)
+            if response.headers["Content-Type"] not in (
+                "image/png",
+                "image/jpeg",
+                "image/jpg",
+            ):
+                response = None
+    except Exception:
+        response = None
     if response is None:
         logger.error(f"Could not get cover art at {new_artwork_url}")
     with tempfile.NamedTemporaryFile() as out_file:
@@ -958,7 +961,7 @@ def set_metadata(track: BasicTrack, filename: str, playlist_info=None, **kwargs)
                 )
             elif mutagen_file.__class__ == mutagen.mp4.MP4:
                 mutagen_file["\xa9cmt"] = track.description
-        if response:
+        if response is not None:
             if mutagen_file.__class__ == mutagen.flac.FLAC:
                 p = mutagen.flac.Picture()
                 p.data = out_file.read()

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -11,7 +11,8 @@ Usage:
     [--download-archive <file>][--sync <file>][--extract-artist][--flac][--original-art]
     [--original-name][--no-original][--only-original][--name-format <format>]
     [--strict-playlist][--playlist-name-format <format>][--client-id <id>]
-    [--auth-token <token>][--overwrite][--no-playlist]
+    [--auth-token <token>][--overwrite][--no-playlist][--playlist-file]
+    [--playlist-file-retain][--playlist-file-name][--playlist-file-extension]
     
     scdl -h | --help
     scdl --version
@@ -64,6 +65,10 @@ Options:
     --overwrite                     Overwrite file if it already exists
     --strict-playlist               Abort playlist downloading if one track fails to download
     --no-playlist                   Skip downloading playlists
+    --playlist-file                 Generate m3u playlist files (and additionally check them when used with --remove)
+    --playlist-file-retain          Retain corrupted items
+    --playlist-file-name            Specify playlist file name without extension
+    --playlist-file-extension       Specify extension to playlist file
 """
 
 import cgi

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -333,7 +333,8 @@ def download_url(client: SoundCloud, **kwargs):
             logger.info(f"Retrieving all likes of user {user.username}...")
             playlistbuffer=None if not kwargs.get("playlist_file") else []
             subplaylistbuffer=None if not kwargs.get("playlist_file") else []
-            resources = client.get_user_likes(user.id, limit=1000)
+            resources = client.get_user_likes(user.id, limit=int(kwdefget("n", "1000", **kwargs)))
+            ilim=int(kwdefget("n", "-1", **kwargs))
             for i, like in itertools.islice(enumerate(resources, 1), offset, None):
                 logger.info(f"like n°{i} of {user.likes_count}")
                 if hasattr(like, "track"):
@@ -344,6 +345,8 @@ def download_url(client: SoundCloud, **kwargs):
                     logger.error(f"Unknown like type {like}")
                     if kwargs.get("strict_playlist"):
                         sys.exit(1)
+                ilim=ilim-1
+                if ilim == 0: break
             if kwargs.get("playlist_file"):
                 playlist_process(client, playlistbuffer, kwdefget("playlist_file_name", "Likes", **kwargs) + "." + kwdefget("playlist_file_extension", "m3u8", **kwargs), **kwargs)
                 playlist_process(client, subplaylistbuffer, kwdefget("playlist_file_name", "Likes Playlists", **kwargs) + "." + kwdefget("playlist_file_extension", "m3u8", **kwargs), no_export=True, **kwargs)

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -422,15 +422,24 @@ def download_url(client: SoundCloud, **kwargs):
         logger.error(f"Unknown item type {item.kind}")
         sys.exit(1)
 
-def remove_files():
+def remove_files(check_playlist_file, playlist_file_extension):
     """
     Removes any pre-existing tracks that were not just downloaded
     """
     logger.info("Removing local track files that were not downloaded...")
-    files = [f for f in os.listdir(".") if os.path.isfile(f)]
-    for f in files:
-        if f not in fileToKeep:
-            os.remove(f)
+    dirs = [d for d in os.listdir(".") if os.path.isdir(d)]
+    dirs.insert(0, ".")
+    for d in dirs:
+        files = [f for f in os.listdir(d) if os.path.isfile(f)]
+        playlist_file = next((f for f in files if f.endswith(playlist_file_extension)), None)
+        if playlist_file is None: continue
+        logger.debug(f"Removing from {d}")
+        playlist_data = playlist_import(playlist_file)
+        if playlist_data is None: continue
+        for f in files:
+            if not f.endswith(playlist_file_extension) and not f.endswith(playlist_file_extension + ".map") and f not in fileToKeep and f not in playlist_data:
+                logger.info(f"Deleting {f}")
+                os.remove(os.path.join(d, f))
 
 def sync(client: SoundCloud, playlist: BasicAlbumPlaylist, playlist_info, **kwargs):
     """

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -368,17 +368,22 @@ def download_url(client: SoundCloud, **kwargs):
             logger.info(f"Downloaded all tracks of user {user.username}!")
         if kwargs.get("a"):
             logger.info(f"Retrieving all tracks & reposts of user {user.username}...")
+            playlistbuffer=None if not kwargs.get("playlist_file") else []
+            subplaylistbuffer=None if not kwargs.get("playlist_file") else []
             resources = client.get_user_stream(user.id, limit=1000)
             for i, item in itertools.islice(enumerate(resources, 1), offset, None):
                 logger.info(f"item n°{i} of {user.track_count + user.reposts_count if user.reposts_count else '?'}")
                 if item.type in ("track", "track-repost"):
-                    download_track(client, item.track, exit_on_fail=kwargs.get("strict_playlist"), **kwargs)
+                    download_track(client, item.track, exit_on_fail=kwargs.get("strict_playlist"), playlist_buffer=playlistbuffer, **kwargs)
                 elif item.type in ("playlist", "playlist-repost"):
-                    download_playlist(client, item.playlist, **kwargs)
+                    download_playlist(client, item.playlist, kwdefget("playlist_file_name", "Stream", **kwargs) + " - ", subplaylist_buffer=subplaylistbuffer, **kwargs)
                 else:
                     logger.error(f"Unknown item type {item.type}")
                     if kwargs.get("strict_playlist"):
                         sys.exit(1)
+            if kwargs.get("playlist_file"):
+                playlist_process(client, playlistbuffer, kwdefget("playlist_file_name", "Stream", **kwargs) + "." + kwdefget("playlist_file_extension", "m3u8", **kwargs), **kwargs)
+                playlist_process(client, subplaylistbuffer, kwdefget("playlist_file_name", "Stream Playlists", **kwargs) + "." + kwdefget("playlist_file_extension", "m3u8", **kwargs), no_export=True, **kwargs)
             logger.info(f"Downloaded all tracks & reposts of user {user.username}!")
         if kwargs.get("p"):
             logger.info(f"Retrieving all playlists of user {user.username}...")

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -1060,6 +1060,18 @@ def playlist_process(client: SoundCloud, playlist_buffer, playlist_filename, no_
 
 
 
+def playlist_import(playlist_filename):
+    try:
+        res = []
+        if not os.path.isfile(playlist_filename): return None
+        with open(playlist_filename, "r") as fin:
+            for fline in fin.read().splitlines():
+                if not fline.startswith("#"): res.append(fline)
+                    
+        return res
+    except Exception:
+        return None
+
 def playlist_export(playlist_buffer, playlist_filename):
     with open(playlist_filename, "w") as fout:
         for playlist_item in playlist_buffer:

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -1093,6 +1093,24 @@ def playlist_export(playlist_buffer, playlist_filename):
         for playlist_item in playlist_buffer:
             fout.write(playlist_item["path"] + "\n")
 
+def check_item(client: SoundCloud, itemuri):
+    item = client.resolve(itemuri)
+    if not item:
+        return False
+    elif item.kind == "track":
+        if item.policy == "BLOCK": return False
+        if item.downloadable and client.get_track_original_download(item.id, item.secret_token): return True
+        if not item.media.transcodings: return False
+        for t in item.media.transcodings:
+            if t.format.protocol == "hls" and "aac" in t.preset: return True
+            elif t.format.protocol == "hls" and "mp3" in t.preset: return True
+        return False
+    elif item.kind == "playlist":
+        return item.tracks is not None and len(item.tracks) > 0
+    elif item.kind == "user":
+        return True
+    else:
+        return False
 
 if __name__ == "__main__":
     main()

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -112,6 +112,9 @@ fileToKeep = []
 class SoundCloudException(Exception):
     pass
 
+class SoundCloudSoftException(Exception):
+    pass
+
 def handle_exception(exc_type, exc_value, exc_traceback):
     if issubclass(exc_type, KeyboardInterrupt):
         logger.error("\nGoodbye!")


### PR DESCRIPTION
First of all thank you for your downloader script!
To increase interoperability with media servers, I've added m3u playlist generation. Observing seldom, yet unresolvable hickup I've decided to add a failsafe mechanism that keeps playlists intact on recurrent runs. Likewise, if playlists are used, the cleanup function will only delete files that are not present in the respective folder's playlist. Furthermore I've enabled processing multiple requests on user profiles and set up a CD to deliver a docker image for testing under releases.
With kind regards,
Michael