### PR TITLE
Basic Implementation of User Listening History Download 

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
-#print("hard fucliong:")
-#exit()
 """scdl allows you to download music from Soundcloud
 
 Usage:
@@ -138,10 +136,6 @@ def main():
     arguments = docopt(__doc__, version=__version__)
 
 
-    if arguments["--history"]:
-        print("asdhgfosaidnaiabngoland")
-        print(arguments["-n"], arguments["-o"])
-        exit(123)
 
     if arguments["--debug"]:
         logger.level = logging.DEBUG
@@ -338,6 +332,7 @@ def download_url(client: SoundCloud, **kwargs):
                     if kwargs.get("strict_playlist"):
                         sys.exit(1)
             logger.info(f"Downloaded all likes of user {user.username}!")
+
         elif kwargs.get("C"):
             logger.info(f"Retrieving all commented tracks of user {user.username}...")
             resources = client.get_user_comments(user.id, limit=1000)
@@ -345,6 +340,25 @@ def download_url(client: SoundCloud, **kwargs):
                 logger.info(f"comment n°{i} of {user.comments_count}")
                 download_track(client, client.get_track(comment.track.id), exit_on_fail=kwargs.get("strict_playlist"), **kwargs)
             logger.info(f"Downloaded all commented tracks of user {user.username}!")
+
+        elif kwargs.get("history"):
+            """Retrieve all listening history of user"""
+            # Write string into logger.info that considers -n flag when displaying message. where n is a integer which if None then it will display string empty string
+            # by copilot
+            logger.info(f"Retrieving all listening history of user {user.username} {'upto last {} tracks'.format(kwargs.get('n')) if kwargs.get('n') else ''}...")
+            history = client.get_history(limit=kwargs.get('n'))
+            for i, track in itertools.islice(enumerate(history.tracks, 1), offset, None):
+                logger.info(f"track n°{i} of {len(history.tracks)}")
+                if hasattr(track, "track"):
+                    download_track(client, track.track, exit_on_fail=kwargs.get("strict_playlist"), **kwargs)
+#                elif hasattr(like, "playlist"):
+#                    download_playlist(client, client.get_playlist(like.playlist.id), **kwargs)
+                else:
+                    logger.error(f"Unknown history track type {track}")
+#                    if kwargs.get("strict_playlist"):
+#                        sys.exit(1)
+            logger.info(f"Downloaded all history of user {user.username}!{'upto last {} tracks'.format(kwargs.get('n')) if kwargs.get('n') else ''}...")
+
         elif kwargs.get("t"):
             logger.info(f"Retrieving all tracks of user {user.username}...")
             resources = client.get_user_tracks(user.id, limit=1000)
@@ -965,6 +979,4 @@ def is_ffmpeg_available():
     return shutil.which("ffmpeg") is not None
 
 if __name__ == "__main__":
-#    print("hard fucking")
-#    exit()
     main()

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
-
+#print("hard fucliong:")
+#exit()
 """scdl allows you to download music from Soundcloud
 
 Usage:
@@ -122,6 +123,7 @@ def handle_exception(exc_type, exc_value, exc_traceback):
 sys.excepthook = handle_exception
 
 def main():
+    print("hard fucking")
     """
     Main function, parses the URL from command line arguments
     """
@@ -956,4 +958,6 @@ def is_ffmpeg_available():
     return shutil.which("ffmpeg") is not None
 
 if __name__ == "__main__":
+#    print("hard fucking")
+#    exit()
     main()

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -8,7 +8,7 @@ Usage:
     scdl (-l <track_url> | me) [-a | -f | -C | -t | -p | -r][-c | --force-metadata]
     [-n <maxtracks>][-o <offset>][--hidewarnings][--debug | --error][--path <path>]
     [--addtofile][--addtimestamp][--onlymp3][--hide-progress][--min-size <size>]
-    [--max-size <size>][--remove][--no-album-tag][--no-playlist-folder]
+    [--max-size <size>][--remove][--no-album-tag][--no-playlist-folder][--history]
     [--download-archive <file>][--sync <file>][--extract-artist][--flac][--original-art]
     [--original-name][--no-original][--only-original][--name-format <format>]
     [--strict-playlist][--playlist-name-format <format>][--client-id <id>]
@@ -39,6 +39,8 @@ Options:
     --debug                         Set log level to DEBUG
     --download-archive [file]       Keep track of track IDs in an archive file,
                                     and skip already-downloaded files
+
+    --history                       Download Listening History
     --error                         Set log level to ERROR
     --extract-artist                Set artist tag from title instead of username
     --hide-progress                 Hide the wget progress bar
@@ -123,7 +125,6 @@ def handle_exception(exc_type, exc_value, exc_traceback):
 sys.excepthook = handle_exception
 
 def main():
-    print("hard fucking")
     """
     Main function, parses the URL from command line arguments
     """
@@ -135,6 +136,12 @@ def main():
 
     # Parse arguments
     arguments = docopt(__doc__, version=__version__)
+
+
+    if arguments["--history"]:
+        print("asdhgfosaidnaiabngoland")
+        print(arguments["-n"], arguments["-o"])
+        exit(123)
 
     if arguments["--debug"]:
         logger.level = logging.DEBUG


### PR DESCRIPTION
I successfully add listening history download to scdl. In many of my attempts  to download I have always got the desired result .

My Code is very non-invasive to the codebase almost like blue in sky, as you might expect.

Ok so the test may fail because @7x11x13  of soundcloud.py API wrapper hasn't yet merged my work of adding history endpoint to the wrapper whose PR you can see [here](https://github.com/7x11x13/soundcloud.py/pull/6) 

So to test on your computer you can check my [fork](https://github.com/CosmicSage/soundcloud.py) and copy paste two files to your site-packages (that's what I did in development)

Look if this gets merged I will make it cleaner and enhance this new feature as well, as the api returns few more data fields which are not considered while downloading.

Hope you like it. Please merge fast 

Thank you 