### PR TITLE
sanitize_filename fix

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -450,14 +450,16 @@ def download_playlist(client: SoundCloud, playlist: BasicAlbumPlaylist, **kwargs
         logger.info("Skipping playlist...")
         return
     playlist_name = playlist.title.encode("utf-8", "ignore")
-    playlist_name = playlist_name.decode("utf-8")
+    playlist_name = playlist_name.decode("utf-8") 
     playlist_name = sanitize_filename(playlist_name)
+    if playlist_name == '':
+        playlist_name = playlist.permalink
     playlist_info = {
                 "author": playlist.user.username,
                 "id": playlist.id,
                 "title": playlist.title
     }
-
+    
     if not kwargs.get("no_playlist_folder"):
         if not os.path.exists(playlist_name):
             os.makedirs(playlist_name)


### PR DESCRIPTION
Sanitizes a string for use as a folder or filename while preserving the extension.

Solves the following cases but importantly handles hidden files/folders (dotfiles) and a folder sanitization issue (#479)
```python
class TestSanitizeStr(unittest.TestCase):
    def test_sanitize_str(self):
        self.assertEqual(sanitize_str('...', '�', '.mp3'), '���')
        self.assertEqual(sanitize_str('..bruh..', '�', '.mp3'), 'bruh..')
        self.assertEqual(sanitize_str('.99999223hd"""', '�', '.mp3'), '99999223hd���')
        self.assertEqual(sanitize_str('....', '�', '.flac'), '����')
        self.assertEqual(sanitize_str('file.name', '�', '.txt'), 'file.name')
        self.assertEqual(sanitize_str('   leading_space', '�', '.pdf'), 'leading_space')
        self.assertEqual(sanitize_str('trailing_space   ', '�', '.docx'), 'trailing_space   ')
        self.assertEqual(sanitize_str('mix"ed...c/hars!!$$$', '�', '.csv'), 'mix�ed...c�hars!!$$$')
        self.assertEqual(sanitize_str('..hiddenfile', '�', '.hidden'), 'hiddenfile')
        self.assertEqual(sanitize_str('..', '�', '.mp3'), '��')
        self.assertEqual(sanitize_str('a..b..c', '�', '.txt'), 'a..b..c')
        self.assertEqual(sanitize_str('a!@#b$%^c&*()d', '�', '.txt'), 'a!@#b$%^c&�()d')
        self.assertEqual(sanitize_str('multiple   spaces', '�', '.txt'), 'multiple   spaces')
        self.assertEqual(sanitize_str('already_sanitized', '�', '.txt'), 'already_sanitized')

    def test_sanitize_str_no_ext(self):
        self.assertEqual(sanitize_str('...', '�'), '���')
        self.assertEqual(sanitize_str('..bruh..', '�'), 'bruh')  # original behavior except for stripping leading dots
        self.assertEqual(sanitize_str('.99999223hd"""', '�'), '99999223hd���')
        self.assertEqual(sanitize_str('....', '�'), '����')
        self.assertEqual(sanitize_str('filename', '�'), 'filename')
        self.assertEqual(sanitize_str('    leading_space', '�'), 'leading_space')
        self.assertEqual(sanitize_str('trailing_space    ', '�'), 'trailing_space')
        self.assertEqual(sanitize_str('  mix"ed...c/hars!!$$$', '�'), 'mix�ed...c�hars!!$$$')
        self.assertEqual(sanitize_str('....hiddenfile', '�'), 'hiddenfile')
        self.assertEqual(sanitize_str('', '�'), '') 
        self.assertEqual(sanitize_str('..', '�'), '��')
        self.assertEqual(sanitize_str('a..b..c', '�'), 'a..b..c')
        self.assertEqual(sanitize_str('a!@#b$%^c&*()d', '�'), 'a!@#b$%^c&�()d')
        self.assertEqual(sanitize_str('multiple   spaces', '�'), 'multiple   spaces')
        self.assertEqual(sanitize_str('already_sanitized', '�'), 'already_sanitized')
        self.assertEqual(sanitize_str('.hiddenfile', '�'), 'hiddenfile') 
```

```
Ran 2 tests in 0.001s

OK
```