### PR TITLE
Migrate from `cgi.parse_header` to `email.message.Message` due to PEP 594

### DIFF
--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -69,7 +69,6 @@ Options:
 
 import atexit
 import base64
-import cgi
 import configparser
 import itertools
 import logging
@@ -675,7 +674,7 @@ def download_original_file(
 
     # Find filename
     header = r.headers.get("content-disposition")
-    _, params = cgi.parse_header(header)
+    _, params = utils.parse_header(header)
     if "filename*" in params:
         encoding, filename = params["filename*"].split("''")
         filename = urllib.parse.unquote(filename, encoding=encoding)

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -70,6 +70,7 @@ Options:
 import atexit
 import base64
 import configparser
+import email.message
 import itertools
 import logging
 import math
@@ -674,12 +675,9 @@ def download_original_file(
 
     # Find filename
     header = r.headers.get("content-disposition")
-    _, params = utils.parse_header(header)
-    if "filename*" in params:
-        encoding, filename = params["filename*"].split("''")
-        filename = urllib.parse.unquote(filename, encoding=encoding)
-    elif "filename" in params:
-        filename = urllib.parse.unquote(params["filename"], encoding="utf-8")
+    params = utils.parse_header(header)
+    if "filename" in params:
+        filename = urllib.parse.unquote(params["filename"][-1], encoding="utf-8")
     else:
         raise SoundCloudException(f"Could not get filename from content-disposition header: {header}")
 

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -70,7 +70,6 @@ Options:
 import atexit
 import base64
 import configparser
-import email.message
 import itertools
 import logging
 import math

--- a/scdl/utils.py
+++ b/scdl/utils.py
@@ -72,3 +72,40 @@ def size_in_bytes(insize):
         size = size * units[unit.lower().strip()]
 
     return int(size)
+
+
+def _parseparam(s):
+    while s[:1] == ';':
+        s = s[1:]
+        end = s.find(';')
+        while end > 0 and (s.count('"', 0, end) - s.count('\\"', 0, end)) % 2:
+            end = s.find(';', end + 1)
+        if end < 0:
+            end = len(s)
+        f = s[:end]
+        yield f.strip()
+        s = s[end:]
+
+
+def parse_header(line):
+    """Parse a Content-type like header.
+
+    Since cgi module would be removed from python 3.13,
+    parse_header implementation was copied from the original library:
+        https://github.com/python/cpython/blob/3.11/Lib/cgi.py#L238
+
+    Return the main content-type and a dictionary of options.
+    """
+    parts = _parseparam(';' + line)
+    key = parts.__next__()
+    pdict = {}
+    for p in parts:
+        i = p.find('=')
+        if i >= 0:
+            name = p[:i].strip().lower()
+            value = p[i+1:].strip()
+            if len(value) >= 2 and value[0] == value[-1] == '"':
+                value = value[1:-1]
+                value = value.replace('\\\\', '\\').replace('\\"', '"')
+            pdict[name] = value
+    return key, pdict

--- a/scdl/utils.py
+++ b/scdl/utils.py
@@ -5,6 +5,7 @@ Copied from
 https://github.com/davidfischer-ch/pytoolbox/blob/master/pytoolbox/logging.py
 """
 
+import email.message
 import logging
 import re
 from termcolor import colored
@@ -74,38 +75,7 @@ def size_in_bytes(insize):
     return int(size)
 
 
-def _parseparam(s):
-    while s[:1] == ';':
-        s = s[1:]
-        end = s.find(';')
-        while end > 0 and (s.count('"', 0, end) - s.count('\\"', 0, end)) % 2:
-            end = s.find(';', end + 1)
-        if end < 0:
-            end = len(s)
-        f = s[:end]
-        yield f.strip()
-        s = s[end:]
-
-
-def parse_header(line):
-    """Parse a Content-type like header.
-
-    Since cgi module would be removed from python 3.13,
-    parse_header implementation was copied from the original library:
-        https://github.com/python/cpython/blob/3.11/Lib/cgi.py#L238
-
-    Return the main content-type and a dictionary of options.
-    """
-    parts = _parseparam(';' + line)
-    key = parts.__next__()
-    pdict = {}
-    for p in parts:
-        i = p.find('=')
-        if i >= 0:
-            name = p[:i].strip().lower()
-            value = p[i+1:].strip()
-            if len(value) >= 2 and value[0] == value[-1] == '"':
-                value = value[1:-1]
-                value = value.replace('\\\\', '\\').replace('\\"', '"')
-            pdict[name] = value
-    return key, pdict
+def parse_header(content_disposition):
+    message = email.message.Message()
+    message['content-type'] = content_disposition
+    return dict(message.get_params())


### PR DESCRIPTION
Hey,

Because of the [PEP 594](https://peps.python.org/pep-0594/#cgi) the CGI module would be removed in python 3.13.
When importing cgi in python 3.11.4 it already produces a warning, which is very annoying when embedding `scdl` in some other projects:
```python
In [1]: import cgi
<ipython-input-1-9eb0c0c38b7b>:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
  import cgi
```

___
We can't just use `email.message.Message` because it doesn't seem to be working well on our stuff.

cgi:
```python
In [17]: cgi.parse_header('''attachment;filename="SoundCloud%20Download"; filename*=utf-8''track.mp3''')
Out[17]:
('attachment',
 {'filename': 'SoundCloud%20Download', 'filename*': "utf-8''track.mp3"})
```

email.message.Message:
```python
In [15]: m['content-type'] = '''attachment;filename="SoundCloud%20Download"; filename*=utf-8''track.mp3'''

In [16]: dict(m.get_params())
Out[16]: {'attachment': '', 'filename': (None, None, 'utf-8track.mp3')}
```

___
As a side note, I tested this via downloading a track from my account and everything seemed to be working well, but unfortunately, I don't think I can add this as a test because I still don't understand how soundcloud decides whether the original mp3 should be allowed to be downloaded or not.
