### PR TITLE
fix: `curl-cffi` compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ scdl me -f
 --yt-dlp-args                   String with custom args to forward to yt-dlp
 ```
 
+### Using yt-dlp's --impersonate feature
+
+scdl passes arguments to yt-dlp via `--yt-dlp-args`. If you want to use yt-dlp's 
+`--impersonate` feature (to mimic browser fingerprints), you'll need to install 
+scdl with `curl-cffi` included, using:
+
+```bash
+pip install scdl[impersonate]
+# or pip install scdl[impersonate-compat], if you're on macOS < 15.0
+```
 
 ## Features
 * Automatically detect the type of link provided

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ description = "Download Music from Souncloud"
 readme = "README.md"
 requires-python = ">=3.10.0"
 dependencies = [
-    "curl-cffi>=0.14.0",
     "docopt-ng>=0.9.0",
     "mutagen>=1.47.0",
     "soundcloud-v2>=1.6.1",
@@ -19,12 +18,20 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Internet",
     "Topic :: Multimedia :: Sound/Audio",
+]
+
+[project.optional-dependencies]
+impersonate = [
+    "curl-cffi>=0.5.10,!=0.6.*,!=0.7.*,!=0.8.*,!=0.9.*,<0.15; implementation_name=='cpython'",
+]
+
+impersonate-compat = [
+    "curl-cffi==0.13.0",
 ]
 
 [dependency-groups]

--- a/scdl/scdl.py
+++ b/scdl/scdl.py
@@ -380,6 +380,18 @@ def _build_ytdl_format_specifier(scdl_args: SCDLArgs) -> str:
         fmt += "[format_id*=mp3]"
     return fmt
 
+def _check_impersonate_support(yt_dlp_args: list[str]) -> None:
+    """Error if --impersonate is used but curl-cffi is not installed."""
+    if "--impersonate" in yt_dlp_args or any(arg.startswith("--impersonate") for arg in yt_dlp_args):
+        try:
+            import curl_cffi  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "The --impersonate flag requires curl-cffi.\n\n"
+                "Install scdl with the impersonate extra to use this feature:"
+                "\npip install scdl[impersonate]"
+                "\n\nor if you're on macOS < 15.0, pip install scdl[impersonate-compat]"
+            ) from None
 
 def _build_ytdl_params(url: str, scdl_args: SCDLArgs) -> tuple[str, dict, list]:
     # return download url, ytdl params, and postprocessors
@@ -537,6 +549,7 @@ def download_url(url: str, **scdl_args: Unpack[SCDLArgs]) -> None:
     yt_dlp_args = scdl_args.get("yt_dlp_args")
     if yt_dlp_args:
         argv = shlex.split(yt_dlp_args)
+        _check_impersonate_support(argv)
         overrides = utils.cli_to_api(argv)
         params = {**params, **overrides}
 


### PR DESCRIPTION
make `curl-cffi` an optional dependency (since it's optional in `yt-dlp` as well)
fixes https://github.com/scdl-org/scdl/issues/580