### PR TITLE
use yt-dlp[curl-cffi] extra instead of separate pin

### DIFF
--- a/.github/workflows/update-yt-dlp.yml
+++ b/.github/workflows/update-yt-dlp.yml
@@ -19,13 +19,13 @@ jobs:
     - name: Get current yt-dlp version
       id: current
       run: |
-        VERSION=$(grep -E '"yt-dlp>=' pyproject.toml | sed -E 's/.*yt-dlp>=([^"]+)".*/\1/')
+        VERSION=$(grep -E '"yt-dlp(\[[^]]+\])?>=' pyproject.toml | sed -E 's/.*yt-dlp(\[[^]]+\])?>=([^"]+)".*/\2/')
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
     - name: Bump versions
       id: bump
       if: steps.latest.outputs.version != steps.current.outputs.version
       run: |
-        sed -i -E 's/("yt-dlp>=)[^"]+(")/\1${{ steps.latest.outputs.version }}\2/' pyproject.toml
+        sed -i -E 's/("yt-dlp(\[[^]]+\])?>=)[^"]+(")/\1${{ steps.latest.outputs.version }}\3/' pyproject.toml
         CURRENT_SCDL=$(grep -E '^version = ' pyproject.toml | head -n1 | sed -E 's/version = "([^"]+)"/\1/')
         NEW_SCDL=$(python3 -c "v='$CURRENT_SCDL'.split('.'); v[2]=str(int(v[2])+1); print('.'.join(v))")
         sed -i -E "s/^version = \"$CURRENT_SCDL\"\$/version = \"$NEW_SCDL\"/" pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,10 @@ description = "Download Music from Souncloud"
 readme = "README.md"
 requires-python = ">=3.10.0"
 dependencies = [
-    "curl-cffi>=0.14.0",
     "docopt-ng>=0.9.0",
     "mutagen>=1.47.0",
     "soundcloud-v2>=1.6.1",
-    "yt-dlp>=2026.2.21",
+    "yt-dlp[curl-cffi]>=2026.2.21",
 ]
 classifiers = [
     "Programming Language :: Python",

--- a/uv.lock
+++ b/uv.lock
@@ -424,11 +424,10 @@ name = "scdl"
 version = "3.0.4"
 source = { editable = "." }
 dependencies = [
-    { name = "curl-cffi" },
     { name = "docopt-ng" },
     { name = "mutagen" },
     { name = "soundcloud-v2" },
-    { name = "yt-dlp" },
+    { name = "yt-dlp", extra = ["curl-cffi"] },
 ]
 
 [package.dev-dependencies]
@@ -444,11 +443,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "curl-cffi", specifier = ">=0.14.0" },
     { name = "docopt-ng", specifier = ">=0.9.0" },
     { name = "mutagen", specifier = ">=1.47.0" },
     { name = "soundcloud-v2", specifier = ">=1.6.1" },
-    { name = "yt-dlp", specifier = ">=2026.2.21" },
+    { name = "yt-dlp", extras = ["curl-cffi"], specifier = ">=2026.2.21" },
 ]
 
 [package.metadata.requires-dev]
@@ -561,4 +559,9 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/d9/55ffff25204733e94a507552ad984d5a8a8e4f9d1f0d91763e6b1a41c79b/yt_dlp-2026.2.21.tar.gz", hash = "sha256:4407dfc1a71fec0dee5ef916a8d4b66057812939b509ae45451fa8fb4376b539", size = 3116630 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/40/664c99ee36d80d84ce7a96cd98aebcb3d16c19e6c3ad3461d2cf5424040e/yt_dlp-2026.2.21-py3-none-any.whl", hash = "sha256:0d8408f5b6d20487f5caeb946dfd04f9bcd2f1a3a125b744a0a982b590e449f7", size = 3313392 },
+]
+
+[package.optional-dependencies]
+curl-cffi = [
+    { name = "curl-cffi", marker = "implementation_name == 'cpython'" },
 ]


### PR DESCRIPTION
## Summary
Switch from depending on `yt-dlp` and `curl-cffi` separately to depending on `yt-dlp[curl-cffi]`. This sources curl-cffi via yt-dlp's own optional-extra version range, so we don't have to maintain a parallel pin that can drift out of sync with what yt-dlp actually needs.

- `pyproject.toml`: dropped `curl-cffi>=0.14.0`, changed `yt-dlp>=2026.2.21` → `yt-dlp[curl-cffi]>=2026.2.21`.
- `uv.lock`: regenerated. `curl-cffi` is now pulled in via yt-dlp's extra, gated by yt-dlp's own `implementation_name == 'cpython'` marker.
- Verified no scdl source file imports `curl_cffi` directly, so dropping the explicit dep is safe.

## Test plan
- [ ] `uv sync` resolves without errors.
- [ ] `uv run scdl --help` runs (sanity check that curl-cffi is still present transitively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)